### PR TITLE
fix(plugin): updated the plugin template bundler configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const webpack = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const nodeExternals = require('webpack-node-externals');
 
 /** @type {import("webpack").Configuration} */
 module.exports = {
@@ -40,5 +39,5 @@ module.exports = {
     libraryTarget: "commonjs2",
     clean: true,
   },
-  externals: [nodeExternals()]
+  externals: ["@amplication/code-gen-utils", "@amplication/code-gen-types"]
 };


### PR DESCRIPTION
# PR Details
Updated the plugin template bundler configuration by replacing the externals.
Removed the dependency to `webpack-node-externals`
Files changed :
webpack.config.js



# Closes
Part of : https://github.com/amplication/amplication/issues/7150